### PR TITLE
Updated to remove case sensitivity of WorkflowID

### DIFF
--- a/SQLSelectQuery/SQLSelectQuery/SQLSelectQuery.cs
+++ b/SQLSelectQuery/SQLSelectQuery/SQLSelectQuery.cs
@@ -53,7 +53,7 @@ namespace SQLSelectQuery
                     //Query PropertyMapping.xml for the relevant Workflow's Field IDs
                     if (workflowID != "")
                     {
-                        PropertyMap workflowProperties = propertyMap.Workflows.Where(x => x.WorkflowID == workflowID).FirstOrDefault();
+                        PropertyMap workflowProperties = propertyMap.Workflows.Where(x => x.WorkflowID.ToLower() == workflowID.ToLower()).FirstOrDefault();
                         
                         if (workflowProperties != null)
                         {


### PR DESCRIPTION
I have updated the comparison between the WorkflowID value in the XML and that which was provided within the Input dictionary from the process field in the workflow. This update removed the case sensitive nature of the WorkflowID. Now WorkflowID=SAMPLE will match the XML even if the XML shows the WorkflowID as 
..
<WorkflowID>Sample</WorkflowID>
..